### PR TITLE
Remove </think> reasoning tags from output (fixes GLM 4.7)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1810,6 +1810,9 @@ def remove_thinking_tags(text: str) -> str:
     
     # Also remove self-closing thinking tags
     text = re.sub(r'<(\w*think\w*)[^>]*/>', '', text, flags=re.IGNORECASE)
+
+    # Also remove stray/orphan closing tags (e.g. </think>, </thinking>)
+    text = re.sub(r'</\w*think\w*>', '', text, flags=re.IGNORECASE)
     
     # Clean up extra whitespace
     text = re.sub(r'\n\s*\n', '\n\n', text)

--- a/main.py
+++ b/main.py
@@ -1810,14 +1810,15 @@ def remove_thinking_tags(text: str) -> str:
     
     # Also remove self-closing thinking tags
     text = re.sub(r'<(\w*think\w*)[^>]*/>', '', text, flags=re.IGNORECASE)
-
+    
     # Also remove stray/orphan closing tags (e.g. </think>, </thinking>)
-    text = re.sub(r'</\w*think\w*>', '', text, flags=re.IGNORECASE)
+    text = re.sub(r'.*?</\w*think\w*>', '', text, flags=re.DOTALL | re.IGNORECASE)
     
     # Clean up extra whitespace
     text = re.sub(r'\n\s*\n', '\n\n', text)
     text = text.strip()
     
+    return text
     return text
 
 def clean_malformed_emojis(text: str, guild: discord.Guild = None) -> str:


### PR DESCRIPTION
Fixes an issue with GLM 4.7 reasoning output leaking into bot responses.